### PR TITLE
fix typo

### DIFF
--- a/src/CommentManager.js
+++ b/src/CommentManager.js
@@ -269,7 +269,7 @@ var CommentManager = (function() {
                 try {
                     this._listeners[event][i](data);
                 } catch (e) {
-                    console.err(e.stack);
+                    console.error(e.stack);
                 }
             }
         }


### PR DESCRIPTION
> 在使用库的过程中，发现dispatchEvent报错，然后发现原因是catch块中 console.err导致，应该为console.error
```javascript
 CommentManager.prototype.dispatchEvent = function (event, data) {
   if (typeof this._listeners[event] !== "undefined") {
     for (var i = 0; i < this._listeners[event].length; i++) {
       try {
         this._listeners[event][i](data);
       } catch (e) {
         console.err(e.stack); 
       }
     }
   }
 };
```